### PR TITLE
Fix submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "grammars/NovaSheets"]
 	path = grammars/NovaSheets
-	url = https://github.com/novasheets/vscode
+	url = https://github.com/NovaSheets/vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "grammars/NovaSheets"]
 	path = grammars/NovaSheets
-	url = https://github.com/novasheets/vscode/tree/main/syntaxes
+	url = https://github.com/novasheets/vscode


### PR DESCRIPTION
Notice the breakage with fresh clone:

```sh
$ git clone https://github.com/Nixinova/tmLanguage fresh
$ cd fresh
$ git submodule update --init
Submodule 'grammars/NovaSheets' (https://github.com/novasheets/vscode/tree/main/syntaxes) registered for path 'grammars/NovaSheets'
Cloning into '/home/am11/fresh/grammars/NovaSheets'...
fatal: repository 'https://github.com/novasheets/vscode/tree/main/syntaxes/' not found
fatal: clone of 'https://github.com/novasheets/vscode/tree/main/syntaxes' into submodule path '/home/am11/fresh/grammars/NovaSheets' failed
Failed to clone 'grammars/NovaSheets'. Retry scheduled
Cloning into '/home/am11/fresh/grammars/NovaSheets'...
fatal: repository 'https://github.com/novasheets/vscode/tree/main/syntaxes/' not found
fatal: clone of 'https://github.com/novasheets/vscode/tree/main/syntaxes' into submodule path '/home/am11/fresh/grammars/NovaSheets' failed
Failed to clone 'grammars/NovaSheets' a second time, aborting
```